### PR TITLE
味方ユニット攻撃範囲調整

### DIFF
--- a/Assets/Battle/Unit/Ally/Ally Prefabs/Ally Sample (1).prefab
+++ b/Assets/Battle/Unit/Ally/Ally Prefabs/Ally Sample (1).prefab
@@ -196,7 +196,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 4, y: 4, z: 1}
+  m_LocalScale: {x: 5, y: 5, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8354871446733301612}

--- a/Assets/Battle/Unit/Ally/Attacks/AttackRangeSetter.cs
+++ b/Assets/Battle/Unit/Ally/Attacks/AttackRangeSetter.cs
@@ -18,7 +18,7 @@ namespace TeamB_TD
 
                     private void Start()
                     {
-                        _transform.localScale = new Vector3(_parameter.AttackRange * 2f, _parameter.AttackRange * 2f, 1f);
+                        _transform.localScale = new Vector3(_parameter.AttackRange, _parameter.AttackRange, 1f);
                     }
                 }
             }

--- a/Assets/Battle/Unit/Ally/ParameterSO/Unit01.asset
+++ b/Assets/Battle/Unit/Ally/ParameterSO/Unit01.asset
@@ -18,5 +18,6 @@ MonoBehaviour:
   _attackPower: 30
   _maxTargetCount: 2
   _cost: 6
-  _attackRange: 3
+  _attackRange: 6
   _attackInterval: 1
+  _allyPrefab: {fileID: 4698916241472948459, guid: 5dacf957a1191a147a084ce106942135, type: 3}

--- a/Assets/Parameter/Ally/AllyParameter.cs
+++ b/Assets/Parameter/Ally/AllyParameter.cs
@@ -4,7 +4,7 @@ namespace TeamB_TD
 {
     [CreateAssetMenu(fileName = "AllyUnitParameter", menuName = "ScriptableObjects/CreateAllyUnitParameter")]
 
-    public class AllyParameter : ScriptableObject , IWeaponType
+    public class AllyParameter : ScriptableObject, IWeaponType
     {
         [SerializeField, Header("近距離or遠距離")] private WeaponType _weaponType;
         [SerializeField, Header("ユニットID")] private int _id;
@@ -23,5 +23,16 @@ namespace TeamB_TD
         public float Cost => _cost;
         public float AttackRange => _attackRange;
         public float AttackInterval => _attackInterval;
+
+        [SerializeField]
+        private GameObject _allyPrefab; // 対応する味方ユニットのプレハブ。
+
+        private void OnValidate()
+        {
+            if (_allyPrefab == null) return;
+            var trigger = _allyPrefab.GetComponentInChildren<Battle.Unit.ColliderTriggerHandler2D>();
+            if (trigger == null) return;
+            trigger.transform.localScale = new Vector3(_attackRange, _attackRange, 1f);
+        }
     }
 }


### PR DESCRIPTION
## タスク概要
* 味方ユニット攻撃範囲調整をちょっとだけ楽にすることを目的に少しだけ調整。

## 具体的にやったこと
* Ally Unit Parametor Scriptable ObjectのAttackRangeを変更したらプレハブにその変更を適用するようにした。
* プレハブ変更モード中であれば保存することで更新が入るので範囲の見える化に貢献した。範囲調整がちょっと楽になった。 

## 動作確認用のスクショや動画
* https://youtu.be/FDA61bEsTlw

## その他
* 
