### PR TITLE
[update] 攻撃方法の変更を可能に更新。クラフト命令が重複して呼ばれた際の挙動を更新。CraftMenuManagerのバグを修正。

### DIFF
--- a/Assets/Battle/Craft/03 Flag/FlagEffect.cs
+++ b/Assets/Battle/Craft/03 Flag/FlagEffect.cs
@@ -16,9 +16,10 @@ namespace TeamB_TD
                 [SerializeField]
                 private FlagParam[] _flagParams;
 
+                private CancellationTokenSource _effectCancellationTokenSource;
+
                 public FlagParam[] FlagParams => _flagParams;
                 public override CraftableParameter[] Parameters => _flagParams;
-
                 public override CraftType CraftType => CraftType.Flag;
 
                 public override void RequestEffect(AllyController user, int level, CancellationToken token = default)
@@ -26,7 +27,13 @@ namespace TeamB_TD
                     base.RequestEffect(user, level, token);
                     var index = level - 1;
                     var param = _flagParams[index];
-                    PlayEffect(param, token);
+
+                    _effectCancellationTokenSource?.Cancel();
+                    _effectCancellationTokenSource = new CancellationTokenSource();
+
+                    var linkedTokenSource = CancellationTokenSource.CreateLinkedTokenSource(_effectCancellationTokenSource.Token, token);
+
+                    PlayEffect(param, linkedTokenSource.Token);
                 }
 
                 private async void PlayEffect(FlagParam param, CancellationToken token)
@@ -45,7 +52,7 @@ namespace TeamB_TD
                         catch (OperationCanceledException)
                         {
                             Debug.Log("Canceled");
-                            return;
+                            break;
                         }
                     }
 

--- a/Assets/Battle/Craft/SampleScene.unity
+++ b/Assets/Battle/Craft/SampleScene.unity
@@ -295,6 +295,7 @@ GameObject:
   - component: {fileID: 220943950}
   - component: {fileID: 220943949}
   - component: {fileID: 220943953}
+  - component: {fileID: 220943954}
   m_Layer: 0
   m_Name: Circle (2) Bomb
   m_TagString: Untagged
@@ -414,7 +415,8 @@ Transform:
   m_LocalPosition: {x: 0, y: 5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 1897916150}
   m_Father: {fileID: 950627207}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &220943953
@@ -435,12 +437,35 @@ MonoBehaviour:
     _currentLife: 10
   _attackController:
     _allyAttack:
-      rid: -2
+      rid: 1259261228002836485
   references:
     version: 2
     RefIds:
-    - rid: -2
-      type: {class: , ns: , asm: }
+    - rid: 1259261228002836485
+      type: {class: AllyAllAttack, ns: TeamB_TD.Battle.Unit.Ally, asm: Assembly-CSharp}
+      data:
+        _multiObjectInTriggerFinder:
+          _colliderTriggerHandler: {fileID: 1897916153}
+--- !u!114 &220943954
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 220943948}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b972c3c9ab0e594884eca51123a0212, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _select:
+    rid: 1259261228002836480
+  references:
+    version: 2
+    RefIds:
+    - rid: 1259261228002836480
+      type: {class: BombAttack, ns: TeamB_TD.Battle.Unit.Ally, asm: Assembly-CSharp}
+      data: 
 --- !u!1001 &256037091
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -449,6 +474,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 528335085153280673, guid: c0d4a5d07a0383944abcb97d5d50d957, type: 3}
+      propertyPath: _layerMask.m_Bits
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3256877653996316294, guid: c0d4a5d07a0383944abcb97d5d50d957, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -1322,6 +1351,167 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1897916149
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1897916150}
+  - component: {fileID: 1897916152}
+  - component: {fileID: 1897916151}
+  - component: {fileID: 1897916153}
+  - component: {fileID: 1897916154}
+  m_Layer: 5
+  m_Name: Circle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1897916150
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1897916149}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 220943952}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!58 &1897916151
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1897916149}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.5
+--- !u!212 &1897916152
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1897916149}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &1897916153
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1897916149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2971c938eff334944a02780a8b161aa0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!50 &1897916154
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1897916149}
+  m_BodyType: 1
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
 --- !u!1 &1963510854
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Battle/Craft/Utility/MouseUtility.cs
+++ b/Assets/Battle/Craft/Utility/MouseUtility.cs
@@ -31,7 +31,7 @@ namespace TeamB_TD
                 public static bool GetMouseOverlappingCollider2D(out RaycastHit2D hit, LayerMask layerMask)
                 {
                     Vector2 mousePosition = Camera.main.ScreenToWorldPoint(new Vector3(Input.mousePosition.x, Input.mousePosition.y, 10f));
-                    hit = Physics2D.Raycast(mousePosition, Vector2.zero);
+                    hit = Physics2D.Raycast(mousePosition, Vector2.zero, Mathf.Infinity, layerMask);
 
                     return hit.collider != null;
                 }

--- a/Assets/Battle/Unit/Ally/Attacks/AllyAllAttack.cs
+++ b/Assets/Battle/Unit/Ally/Attacks/AllyAllAttack.cs
@@ -14,6 +14,8 @@ namespace TeamB_TD
                     [SerializeField]
                     private MultiObjectsInTriggerFinder2D _multiObjectInTriggerFinder;
 
+                    public float AttackAnimationTime => 1.5f;
+
                     public bool IsAnyObjectInTrigger()
                     {
                         var enemies = _multiObjectInTriggerFinder.GetAllObjectsInTrigger<EnemyController>();

--- a/Assets/Battle/Unit/Ally/Attacks/AllySingleAttack.cs
+++ b/Assets/Battle/Unit/Ally/Attacks/AllySingleAttack.cs
@@ -14,6 +14,8 @@ namespace TeamB_TD
                     [SerializeField]
                     private SingleObjectInTriggerFinder2D _colliderTriggerHandler;
 
+                    public float AttackAnimationTime => 0.2f;
+
                     public bool IsAnyObjectInTrigger()
                     {
                         var enemy = _colliderTriggerHandler.GetFirstEnteredObject<EnemyController>();

--- a/Assets/Battle/Unit/Ally/Attacks/AttackStyleMultiSelecter.cs
+++ b/Assets/Battle/Unit/Ally/Attacks/AttackStyleMultiSelecter.cs
@@ -1,0 +1,22 @@
+﻿using Glib.InspectorExtension;
+using UnityEngine;
+
+namespace TeamB_TD
+{
+    namespace Battle
+    {
+        namespace Unit
+        {
+            namespace Ally
+            {
+                public class AttackStyleMultiSelecter : MonoBehaviour
+                {
+                    [SerializeReference, SubclassSelector]
+                    private IAllyAttack[] _allyAttacks;
+
+                    public IAllyAttack[] AllyAttacks => _allyAttacks;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Battle/Unit/Ally/Attacks/AttackStyleMultiSelecter.cs.meta
+++ b/Assets/Battle/Unit/Ally/Attacks/AttackStyleMultiSelecter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c816294cbbd5284f9d69172a84a4612
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Battle/Unit/Ally/Attacks/AttackStyleSingleSelecter.cs
+++ b/Assets/Battle/Unit/Ally/Attacks/AttackStyleSingleSelecter.cs
@@ -1,0 +1,22 @@
+﻿using UnityEngine;
+using Glib.InspectorExtension;
+
+namespace TeamB_TD
+{
+    namespace Battle
+    {
+        namespace Unit
+        {
+            namespace Ally
+            {
+                public class AttackStyleSingleSelecter : MonoBehaviour
+                {
+                    [SerializeReference, SubclassSelector]
+                    private IAllyAttack _select;
+
+                    public IAllyAttack Select => _select;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Battle/Unit/Ally/Attacks/AttackStyleSingleSelecter.cs.meta
+++ b/Assets/Battle/Unit/Ally/Attacks/AttackStyleSingleSelecter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b972c3c9ab0e594884eca51123a0212
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Battle/Unit/Ally/Attacks/BombAttack.cs
+++ b/Assets/Battle/Unit/Ally/Attacks/BombAttack.cs
@@ -1,0 +1,26 @@
+﻿namespace TeamB_TD
+{
+    namespace Battle
+    {
+        namespace Unit
+        {
+            namespace Ally
+            {
+                public class BombAttack : IAllyAttack
+                {
+                    public float AttackAnimationTime => 0.1f;
+
+                    public void Fire(float attackPower)
+                    {
+
+                    }
+
+                    public bool IsAnyObjectInTrigger()
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/Battle/Unit/Ally/Attacks/BombAttack.cs.meta
+++ b/Assets/Battle/Unit/Ally/Attacks/BombAttack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3d9e83bab2daf974fa67108ab2e4b0ec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Battle/Unit/Ally/Attacks/IAllyAttack.cs
+++ b/Assets/Battle/Unit/Ally/Attacks/IAllyAttack.cs
@@ -6,6 +6,7 @@ namespace TeamB_TD
     {
         public interface IAllyAttack
         {
+            float AttackAnimationTime { get; }
             bool IsAnyObjectInTrigger();
             void Fire(float attackPower);
         }

--- a/Assets/Battle/Unit/Ally/Core/AllyAttackController.cs
+++ b/Assets/Battle/Unit/Ally/Core/AllyAttackController.cs
@@ -18,32 +18,146 @@ namespace TeamB_TD
 
                     private AllyController _controller;
 
-                    private float _attackIntervalTimer = 0f;
+                    private WaitingState _waitingState = null;
+                    private AttackingState _attackingState = null;
+                    private IntervalState _intervalState = null;
 
-                    // トリガー内にオブジェクトが存在し、
-                    // 攻撃インターバルが経過していたら攻撃可能を表現する。
-                    public bool IsAttackable =>
-                        _attackIntervalTimer >= _controller.Param.AttackInterval &&
-                        _allyAttack != null &&
-                        _allyAttack.IsAnyObjectInTrigger();
+                    private AttackState _currentState = null;
+
+                    public IAllyAttack CurrentAttackStyle => _allyAttack;
+                    public AllyController AllyController => _controller;
+
+                    public AttackState CurrentState => _currentState;
 
                     public void Initialize(AllyController controller)
                     {
                         _controller = controller;
+
+                        _waitingState = new WaitingState(this);
+                        _attackingState = new AttackingState(this);
+                        _intervalState = new IntervalState(this);
+
+                        _waitingState.AttackState = _attackingState;
+                        _attackingState.IntervalState = _intervalState;
+                        _intervalState.WaitingState = _waitingState;
+
+                        Transition(_waitingState);
                     }
 
                     public void Update()
                     {
-                        if (_attackIntervalTimer < _controller.Param.AttackInterval)
+                        if (_currentState != null)
+                            _currentState.Update();
+                        else
+                            Debug.Log(nameof(_currentState) + " is null...");
+                    }
+
+                    public void ChangeAttackStyle(IAllyAttack attack)
+                    {
+                        Debug.Log("change attack style");
+                        _allyAttack = attack;
+                        Transition(_waitingState);
+                    }
+
+                    public void Transition(AttackState attackState)
+                    {
+                        _currentState?.Exit();
+                        _currentState = attackState;
+                        _currentState?.Enter();
+                    }
+
+                    public abstract class AttackState
+                    {
+                        public virtual void Enter() { }
+                        public virtual void Update() { }
+                        public virtual void Exit() { }
+                    }
+
+                    private class WaitingState : AttackState
+                    {
+                        public WaitingState(AllyAttackController controller, AttackingState attackState = null)
                         {
-                            var gameSpeed = GameSpeedController.CurretGameSpeed;
-                            _attackIntervalTimer += Time.deltaTime * gameSpeed;
+                            Controller = controller;
+                            AttackState = attackState;
                         }
 
-                        if (IsAttackable)
+                        public AllyAttackController Controller { get; set; }
+                        public AttackingState AttackState { get; set; }
+
+                        public override void Update()
                         {
-                            _allyAttack.Fire(_controller.Param.AttackPower);
-                            _attackIntervalTimer = 0f;
+                            if (Controller.CurrentAttackStyle == null) return; // throw new ArgumentNullException(nameof(Controller.CurrentAttackStyle));
+
+                            if (Controller.CurrentAttackStyle.IsAnyObjectInTrigger())
+                            {
+                                Controller.Transition(AttackState);
+                            }
+                        }
+                    }
+
+                    private class AttackingState : AttackState
+                    {
+                        public AttackingState(AllyAttackController controller, IntervalState intervalState = null)
+                        {
+                            IntervalState = intervalState;
+                            Controller = controller;
+                        }
+
+                        public AllyAttackController Controller { get; set; }
+                        public IntervalState IntervalState { get; set; }
+
+                        private float _timer = 0f;
+
+                        private float AttackPower => Controller.AllyController.Param.AttackPower;
+
+                        public override void Enter()
+                        {
+                            // Debug.Log($"{Controller.CurrentAttackStyle.GetType().Name} Fire!");
+                            Controller.CurrentAttackStyle.Fire(AttackPower);
+                            _timer = 0f;
+                        }
+
+                        public override void Update()
+                        {
+                            _timer += Time.deltaTime * GameSpeedController.CurretGameSpeed;
+
+                            if (Controller.CurrentAttackStyle == null) return; // throw new ArgumentNullException(nameof(Controller.CurrentAttackStyle));
+
+                            if (_timer > Controller.CurrentAttackStyle.AttackAnimationTime)
+                            {
+                                Controller.Transition(IntervalState);
+                            }
+                        }
+                    }
+
+                    private class IntervalState : AttackState
+                    {
+                        public IntervalState(AllyAttackController controller, WaitingState waitingState = null)
+                        {
+                            WaitingState = waitingState;
+                            AttackController = controller;
+                        }
+
+                        public AllyAttackController AttackController { get; set; }
+                        public WaitingState WaitingState { get; set; }
+
+                        private float _timer = 0f;
+
+                        private float AttackInterval => AttackController.AllyController.Param.AttackInterval;
+
+                        public override void Enter()
+                        {
+                            _timer = 0f;
+                        }
+
+                        public override void Update()
+                        {
+                            _timer += Time.deltaTime * GameSpeedController.CurretGameSpeed;
+
+                            if (_timer > AttackInterval)
+                            {
+                                AttackController.Transition(WaitingState);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## タスク概要
* クラフト機能の作成。

## 具体的にやったこと
* ボムで攻撃方法を変更させる必要があるので、味方ユニットの攻撃方法を変更する機能を作成。
* 同じクラフト命令が重複して発行された際、それまで実行されていたクラフト命令を破棄し、新しい命令のみ走るように更新。（一旦 旗と爆弾のみ）
* CraftMenuManagerでLayerMaskを指定することができていたが、適用されていなかったため、適用するように更新。

## 動作確認用のスクショや動画
* なし

## その他
* ひとまず旗と爆弾の完成を目指します。
* 次は旗用に味方ユニットのバフ機能を作ろうと思います。
* その次は爆弾攻撃の中身の実装を行います。