### PR TITLE
Ally再配置関連

### DIFF
--- a/Assets/Battle/Unit/Ally/Ally Prefabs/Ally Manager.prefab
+++ b/Assets/Battle/Unit/Ally/Ally Prefabs/Ally Manager.prefab
@@ -45,9 +45,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _allyPrefabs:
-  - {fileID: 8574549999437753440, guid: 5dacf957a1191a147a084ce106942135, type: 3}
-  - {fileID: 2897221280078880922, guid: 92d77998e1dafc84992d432b8eba5b72, type: 3}
-  - {fileID: 3544527554346160070, guid: e9abaa8e57d9b474bb1c271fcbe0d06f, type: 3}
+  - {fileID: 7637565140579440553, guid: 9101ab5ec9718c3439dc68ab9bae6328, type: 3}
+  - {fileID: 738544455504410529, guid: d83438fce28b1bb43a6d5032a573ef94, type: 3}
+  - {fileID: 6825851784176235795, guid: 766835ec18ba0f040bd842b23fc5a3c4, type: 3}
+  - {fileID: 4060911339381851421, guid: 73d650f66e719cb4f9af4c3092ee9bd7, type: 3}
+  - {fileID: 3094955111388639120, guid: 0f07123f41b028a408c861b7a3654eae, type: 3}
+  - {fileID: 2162883985589684283, guid: d4735a7abd4a49d4a8dfda7409ab3f86, type: 3}
 --- !u!1 &5801694369536806466
 GameObject:
   m_ObjectHideFlags: 0
@@ -93,6 +96,8 @@ GameObject:
   - component: {fileID: 3604494971321203626}
   - component: {fileID: 3249747501328223130}
   - component: {fileID: 7895713803948508844}
+  - component: {fileID: 7500019708981844843}
+  - component: {fileID: 9128240643071744770}
   m_Layer: 0
   m_Name: Ally Place Manager
   m_TagString: Untagged
@@ -142,7 +147,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7c7fb1c74802b0943aec2889ec0589d8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _dragHandler: {fileID: 0}
+  _resourceManager: {fileID: 0}
+  _dragHandler: {fileID: 7895713803948508844}
   _placeOffset: {x: 0, y: 0, z: 0}
 --- !u!114 &7895713803948508844
 MonoBehaviour:
@@ -158,7 +164,33 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _3DColliderLayerMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 0
   _2DColliderLayerMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 256
+--- !u!114 &7500019708981844843
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7376342430812868409}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e0a0802545f968d43a6486ed4e00f289, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _allyPrefabs: {fileID: 7589937647822875755}
+--- !u!114 &9128240643071744770
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7376342430812868409}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f17eee1082f7ac14880cc8dd3367edfa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _allyPlacer: {fileID: 3249747501328223130}

--- a/Assets/Battle/Unit/Ally/Place/AllyPlaceableManager.cs
+++ b/Assets/Battle/Unit/Ally/Place/AllyPlaceableManager.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections.Generic;
+using UnityEngine;
+
+// 日本語対応
+namespace TeamB_TD
+{
+    namespace Battle
+    {
+        namespace Unit
+        {
+            namespace Ally
+            {
+                public class AllyPlaceableManager : MonoBehaviour
+                {
+                    public static AllyPlaceableManager Instance { get; private set; } = null;
+                    public Dictionary<int, (float Erapse, PlaceableStatus Placeable)> WaitForReviving => _waitForReviving;
+
+                    [SerializeField]
+                    private AllyPrefabContainer _allyPrefabs = null;
+
+                    /// <summary>ユニットが亡くなった時、再設置可能になるまでの時間を計測する</summary>
+                    private Dictionary<int, (float Erapse, PlaceableStatus Placeable)> _waitForReviving
+                        = new Dictionary<int, (float, PlaceableStatus)>();
+                    private Dictionary<int, float> _allysRevivalInterval = new Dictionary<int, float>();
+                    private Queue<int> _waitingQueue = new Queue<int>();
+
+                    private void Awake()
+                    {
+                        Instance = this;
+                    }
+
+                    private void Start()
+                    {
+                        if (_allyPrefabs == null) Debug.LogWarning("AllyPrefabContainer is not assigned");
+                        else
+                        {
+                            foreach (var ally in _allyPrefabs.AllyPrefabs)
+                            {
+                                if (_waitForReviving.ContainsKey(ally.ConstantParams.ID)) continue;
+                                _waitForReviving.Add(ally.ConstantParams.ID, (0.0f, PlaceableStatus.Placeable));
+                                _allysRevivalInterval.Add(ally.ConstantParams.ID, ally.ConstantParams.RevivalInterval);
+                            }
+                        }
+                    }
+
+                    public bool IsAllyPlaceable(AllyController ally)
+                    {
+                        return _waitForReviving[ally.ConstantParams.ID].Placeable == PlaceableStatus.Placeable;
+                    }
+
+                    public void PlaceAlly(int allyId)
+                    {
+                        ChangeStatus(allyId, PlaceableStatus.HasPlaced);
+                    }
+
+                    public void OnDeadAlly(AllyController ally)
+                    {
+                        int allyId = ally.ConstantParams.ID;
+                        ChangeStatus(allyId, PlaceableStatus.Reviving);
+                        _waitingQueue.Enqueue(allyId);
+                        ally.OnDeadAlly -= OnDeadAlly;
+                    }
+
+                    public void CalcRevivingTime()
+                    {
+                        if (_waitingQueue.Count == 0) return;
+
+                        for (int i = 0, loopCount = _waitingQueue.Count; i < loopCount; i++)
+                        {
+                            int n = _waitingQueue.Dequeue();
+                            _waitForReviving[n] =
+                                (_waitForReviving[n].Erapse + Time.deltaTime * GameSpeedController.CurretGameSpeed,
+                                PlaceableStatus.Reviving);
+
+                            if (_waitForReviving[n].Erapse < _allysRevivalInterval[n]) { _waitingQueue.Enqueue(n); continue; }
+
+                            ChangeStatus(n, PlaceableStatus.Placeable);
+                        }
+                    }
+
+                    public void ChangeStatus(int allyId, PlaceableStatus status)
+                    {
+                        _waitForReviving[allyId] = (0.0f, status);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/Battle/Unit/Ally/Place/AllyPlaceableManager.cs.meta
+++ b/Assets/Battle/Unit/Ally/Place/AllyPlaceableManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e0a0802545f968d43a6486ed4e00f289
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Battle/Unit/Ally/Place/AllyUnitPlacer.cs
+++ b/Assets/Battle/Unit/Ally/Place/AllyUnitPlacer.cs
@@ -59,6 +59,7 @@ namespace TeamB_TD
 
                             _dragItem.transform.position = mouseWorldPos;
                         }
+                        AllyPlaceableManager.Instance.CalcRevivingTime();
                     }
 
                     private void OnButtonPressed(GameObject mouseOverlappingObject) // ドラッグ開始（マウス左ボタン押下時）
@@ -66,6 +67,8 @@ namespace TeamB_TD
                         if (mouseOverlappingObject &&
                             mouseOverlappingObject.TryGetComponent(out AllyUnitPlaceView placeView))
                         {
+                            if (!AllyPlaceableManager.Instance.IsAllyPlaceable(placeView.AllyPrefab)) return;
+
                             _dragItem = GameObject.Instantiate(placeView.AllyPrefab);
                             _dragItem.enabled = false;
                             _dragItem.GetComponent<Collider2D>().enabled = false;
@@ -78,14 +81,15 @@ namespace TeamB_TD
                     private void OnButtonReleased(GameObject mouseOverlappingObject) // ドラッグ終了（マウス左ボタン解放時）
                     {
                         if (TryGetCell(mouseOverlappingObject, out IStageCell cell) &&
-                            IsPlacable(_dragItem, cell, _resourceManager))
+                            IsPlacable(_dragItem, cell, _resourceManager) &&
+                            AllyPlaceableManager.Instance.IsAllyPlaceable(_dragItem))
                         {
                             Place(_dragItem, cell);
                         }
 
                         if (_dragItem != null)
                         {
-                            GameObject.Destroy(_dragItem.gameObject);
+                            Destroy(_dragItem.gameObject);
                             _dragItem = null;
                         }
                     }
@@ -99,6 +103,8 @@ namespace TeamB_TD
                         allyPrefab.GetComponent<Collider2D>().enabled = true;
                         var position = stageCell.WorldPosition + _placeOffset;
                         var instance = Instantiate(allyPrefab, position, Quaternion.identity);
+                        AllyPlaceableManager.Instance.PlaceAlly(instance.ConstantParams.ID);
+                        instance.OnDeadAlly += AllyPlaceableManager.Instance.OnDeadAlly;
                         _resourceManager.TryUseResource(allyPrefab.ConstantParams.Cost);
                         OnPlacedAlly?.Invoke(instance);
                     }

--- a/Assets/Battle/Unit/Ally/Place/PlaceableStatus.cs
+++ b/Assets/Battle/Unit/Ally/Place/PlaceableStatus.cs
@@ -1,0 +1,19 @@
+﻿// 日本語対応
+namespace TeamB_TD
+{
+    namespace Battle
+    {
+        namespace Unit
+        {
+            namespace Ally
+            {
+                public enum PlaceableStatus
+                {
+                    Placeable = 0,
+                    HasPlaced = 1,
+                    Reviving = 2,
+                }
+            }
+        }
+    }
+}

--- a/Assets/Battle/Unit/Ally/Place/PlaceableStatus.cs.meta
+++ b/Assets/Battle/Unit/Ally/Place/PlaceableStatus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3fd2cf6403133d643922ed7c4ee0a647
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Parameter/Ally/AllyConstantParameter.cs
+++ b/Assets/Parameter/Ally/AllyConstantParameter.cs
@@ -28,6 +28,7 @@ namespace TeamB_TD
         public float RevivalInterval => _revivalInterval;
         public Sprite AllySprite => _allySprite;
 
+        [Header("====================")]
         [SerializeField]
         private GameObject _allyPrefab; // 対応する味方ユニットのプレハブ。
         [SerializeField]


### PR DESCRIPTION
## タスク概要
* Ally配置周りの処理の作成
* 雑務

## 具体的にやったこと
* Allyを１人配置したら、２人目以降は配置できないようにした。
* Allyが撃破されたとき、Allyが持つ復活までの時間が経過するまで配置できないようにした。
* ScriptableObjectのパラメーターを表示する部分と他Assetの参照がシリアライズされている部分を区切った

## 動作確認用のスクショや動画
* https://clipchamp.com/watch/qOK1zrIdUAF

## その他
* 無し
