### PR TITLE
セーブデータに関するデバッグ用の機能の追加...etc

### DIFF
--- a/Assets/OutGame/FavCharaSelect/DecideListener.cs
+++ b/Assets/OutGame/FavCharaSelect/DecideListener.cs
@@ -1,6 +1,9 @@
 ﻿using System.IO;
 using UnityEngine;
 using UnityEngine.UI;
+using TeamB_TD.UI;
+using TeamB_TD.SaveData;
+using Glib.InspectorExtension;
 namespace TeamB_TD
 {
     namespace OutGame
@@ -9,18 +12,22 @@ namespace TeamB_TD
         {
             [HideInInspector] public SaveData.SaveData _pData;
 
-            [SerializeField] GameObject _imgCanvas;
-            [SerializeField] int _characterNum = 6;
-            [SerializeField] Sprite[] _charImgArray;
-            
+            [SerializeField] 
+            GameObject _imgCanvas;
+            [SerializeField]
+            int _characterNum = 6;
+            [SerializeField]
+            Sprite[] _charImgArray;
+            [SerializeField, SceneName] 
+            private string _nextScene;
+
             string _filepath;            
             int _currentNum = 0;
             public int GetNumber => _currentNum;
 
             public static string _json;
 
-            Sprite _dispImg;
-
+            SaveData.SaveData memory;
 
             public SaveData.SaveData PlayerData => _pData;            
             
@@ -28,6 +35,7 @@ namespace TeamB_TD
             {
                 _filepath = Application.streamingAssetsPath + "/SaveData/SaveData.json";
                 _imgCanvas.gameObject.GetComponent<Image>().sprite = _charImgArray[_currentNum];
+                memory = DataManager.Instance.Load(_filepath);
             }
             private void Start()
             {
@@ -39,29 +47,23 @@ namespace TeamB_TD
             }
             public void FavCharDecide()
             {
-                StreamReader rd = new StreamReader(_filepath);
-                _json = rd.ReadToEnd();
-                rd.Close();
-                SaveData.SaveData memory = JsonUtility.FromJson<SaveData.SaveData>(_json);
-                memory._favoriteUnitId = _currentNum;
-                _json = JsonUtility.ToJson(memory);
-                StreamWriter wr = new StreamWriter(_filepath, false);
-                wr.WriteLine(_json);
-                wr.Close();
-                Debug.Log("上書きは正常に動作しています");
+                memory._favoriteUnitId = _currentNum + 1;
+                DataManager.Instance.Save(memory);
+                //Debug.Log("上書きは正常に動作しています");
+                SceneTransition.instance.SceneTrans(_nextScene);
             }
 
             public void SlideRight()
             {
                 _currentNum++;
                 _currentNum %= _characterNum;
-                Debug.Log($"currentNum：{_currentNum}");
+                //Debug.Log($"currentNum：{_currentNum}");
             }
             public void SlideLeft()
             {
                 _currentNum--;
                 if(_currentNum < 0) _currentNum += _characterNum;
-                Debug.Log($"currentNum：{_currentNum}");
+                //Debug.Log($"currentNum：{_currentNum}");
             }
         }
     }

--- a/Assets/OutGame/FavCharaSelect/OathScene.unity
+++ b/Assets/OutGame/FavCharaSelect/OathScene.unity
@@ -355,7 +355,6 @@ RectTransform:
   m_Children:
   - {fileID: 2010625787}
   - {fileID: 86973834}
-  - {fileID: 673168414}
   - {fileID: 881505230}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -388,6 +387,7 @@ MonoBehaviour:
   - {fileID: 21300000, guid: 3c78bd7be5e51ba4f96b1216edf0fbf2, type: 3}
   - {fileID: 21300000, guid: 638ae2a1b1fa84246a2d3944f822d867, type: 3}
   - {fileID: 21300000, guid: d6d75408393213947a363d5a6bf102ce, type: 3}
+  _nextScene: StageSelect
 --- !u!1 &385934470
 GameObject:
   m_ObjectHideFlags: 0
@@ -669,87 +669,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &673168413
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 673168414}
-  - component: {fileID: 673168416}
-  - component: {fileID: 673168415}
-  m_Layer: 5
-  m_Name: CharacterName
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &673168414
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 673168413}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1518709505}
-  - {fileID: 1311821566}
-  m_Father: {fileID: 145941591}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 135, y: 225}
-  m_SizeDelta: {x: 750, y: 85}
-  m_Pivot: {x: 0, y: 0}
---- !u!114 &673168415
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 673168413}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 0.98152006, b: 0, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 75
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 0
-    m_MaxSize: 300
-    m_Alignment: 0
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: "\u304A\u306A\u307E\u3048"
---- !u!222 &673168416
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 673168413}
-  m_CullTransparentMesh: 1
 --- !u!1001 &877088015
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -866,9 +785,17 @@ PrefabInstance:
       propertyPath: _nextScene
       value: StageSelect
       objectReference: {fileID: 0}
+    - target: {fileID: 6193404630159636774, guid: 5ff9248bab74b2f4ebdbb7f8f4a58fc0, type: 3}
+      propertyPath: _anotherNextScene
+      value: Template Scene
+      objectReference: {fileID: 0}
     - target: {fileID: 8415846471290151859, guid: 5ff9248bab74b2f4ebdbb7f8f4a58fc0, type: 3}
       propertyPath: m_Name
       value: ToNextScene
+      objectReference: {fileID: 0}
+    - target: {fileID: 8415846471290151859, guid: 5ff9248bab74b2f4ebdbb7f8f4a58fc0, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8466873696076830902, guid: 5ff9248bab74b2f4ebdbb7f8f4a58fc0, type: 3}
       propertyPath: m_Text
@@ -1235,164 +1162,6 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1216602564}
-  m_CullTransparentMesh: 1
---- !u!1 &1311821565
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1311821566}
-  - component: {fileID: 1311821568}
-  - component: {fileID: 1311821567}
-  m_Layer: 5
-  m_Name: CharacterBackBone
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1311821566
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1311821565}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 673168414}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -400, y: -570}
-  m_SizeDelta: {x: 750, y: 500}
-  m_Pivot: {x: 0, y: 0}
---- !u!114 &1311821567
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1311821565}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0.9045043, g: 0, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 45
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 0
-    m_MaxSize: 104
-    m_Alignment: 0
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 0.9
-  m_Text: "\u30AD......................................................\n\u30E3\n\u30E9\n\u30AF\n\u30BF\n\uFF4C\n\u7D39\n\u4ECB\n\uFF11\n\uFF12\n\nJ\n\n"
---- !u!222 &1311821568
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1311821565}
-  m_CullTransparentMesh: 1
---- !u!1 &1518709504
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1518709505}
-  - component: {fileID: 1518709507}
-  - component: {fileID: 1518709506}
-  m_Layer: 5
-  m_Name: CatchPhrase
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1518709505
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1518709504}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 673168414}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -450, y: 65}
-  m_SizeDelta: {x: 630, y: 30}
-  m_Pivot: {x: 0, y: 0}
---- !u!114 &1518709506
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1518709504}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 0, g: 0.8401151, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 25
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 2
-    m_MaxSize: 40
-    m_Alignment: 0
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: "\u30AD\u30E3\u30C3\u30C1\u30D5\u30EC\u30FC\u30BA"
---- !u!222 &1518709507
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1518709504}
   m_CullTransparentMesh: 1
 --- !u!1 &1544230145
 GameObject:

--- a/Assets/OutGame/Title/TitleScene.unity
+++ b/Assets/OutGame/Title/TitleScene.unity
@@ -1072,7 +1072,7 @@ Canvas:
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
   m_VertexColorAlwaysGammaSpace: 0
-  m_AdditionalShaderChannelsFlag: 0
+  m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 0
@@ -1096,6 +1096,7 @@ RectTransform:
   - {fileID: 947197352}
   - {fileID: 2110679843}
   - {fileID: 1875390965}
+  - {fileID: 2120805319}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -1181,6 +1182,140 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1376267785}
+  m_CullTransparentMesh: 1
+--- !u!1 &1504679282
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1504679283}
+  - component: {fileID: 1504679285}
+  - component: {fileID: 1504679284}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1504679283
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1504679282}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2120805319}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1504679284
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1504679282}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Button
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1504679285
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1504679282}
   m_CullTransparentMesh: 1
 --- !u!1 &1553061905
 GameObject:
@@ -1685,6 +1820,14 @@ PrefabInstance:
       propertyPath: _nextScene
       value: OathScene
       objectReference: {fileID: 0}
+    - target: {fileID: 6193404630159636774, guid: 5ff9248bab74b2f4ebdbb7f8f4a58fc0, type: 3}
+      propertyPath: _sceneDivergence
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6193404630159636774, guid: 5ff9248bab74b2f4ebdbb7f8f4a58fc0, type: 3}
+      propertyPath: _anotherNextScene
+      value: StageSelect
+      objectReference: {fileID: 0}
     - target: {fileID: 8415846471290151859, guid: 5ff9248bab74b2f4ebdbb7f8f4a58fc0, type: 3}
       propertyPath: m_Name
       value: ToNextScene
@@ -1964,6 +2107,139 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2110679842}
+  m_CullTransparentMesh: 1
+--- !u!1 &2120805318
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2120805319}
+  - component: {fileID: 2120805322}
+  - component: {fileID: 2120805321}
+  - component: {fileID: 2120805320}
+  m_Layer: 5
+  m_Name: DebugButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2120805319
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2120805318}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1504679283}
+  m_Father: {fileID: 1365456423}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 700, y: -400}
+  m_SizeDelta: {x: 160, y: 125}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2120805320
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2120805318}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 2120805321}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1752143134}
+        m_TargetAssemblyTypeName: SelectSaveDebug, Assembly-CSharp
+        m_MethodName: FavCharSet
+        m_Mode: 3
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 1
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &2120805321
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2120805318}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2120805322
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2120805318}
   m_CullTransparentMesh: 1
 --- !u!1660057539 &9223372036854775807
 SceneRoots:

--- a/Assets/SelectSaveDebug.cs
+++ b/Assets/SelectSaveDebug.cs
@@ -19,4 +19,9 @@ public class SelectSaveDebug : MonoBehaviour
     {
         DataManager.Instance.Reset();
     }
+
+    public void FavCharSet(int unitID)
+    {
+        DataManager.Instance.ChangeFavchar(unitID);
+    }
 }

--- a/Assets/System/SaveSystem/DataManager.cs
+++ b/Assets/System/SaveSystem/DataManager.cs
@@ -55,9 +55,11 @@ namespace TeamB_TD
             {
                 _json = JsonUtility.ToJson(data);
                 StreamWriter wr = new StreamWriter(_filepath, false);
+                Debug.Log(_json);
                 wr.WriteLine(_json);
                 wr.Flush();
                 wr.Close();
+                _pData = Load(_filepath);
             }
             public SaveData Load(string path)
             {
@@ -69,74 +71,42 @@ namespace TeamB_TD
             }
             public void Reset()
             {
-                StreamReader rd = new StreamReader(_filepath);
-                _json = rd.ReadToEnd();
-                rd.Close();
-                SaveData memory = JsonUtility.FromJson<SaveData>(_json);
+                SaveData memory = Load(_filepath);
                 for (int i = 0; i < memory._isClear.Length; i++)
                 {
                     memory._isClear[i] = false;
                 }
-                _json = JsonUtility.ToJson(memory);
-                StreamWriter wr = new StreamWriter(_filepath, false);
-                Debug.Log(_json);
-                wr.WriteLine(_json);
-                wr.Close();
+                memory._favoriteUnitId = 0;
+                Save(memory);
             }
 
             // 以下デバッグ用
             // TODO:機能整い次第削除
             public void OverWrite(int stagenum) //特定のステージのクリア状況を変更する
             {
-                StreamReader rd = new StreamReader(_filepath);
-                _json = rd.ReadToEnd();
-                rd.Close();
-                SaveData memory = JsonUtility.FromJson<SaveData>(_json);
+                SaveData memory = Load(_filepath);
                 for (int i = 0; i < stagenum; i++)
                 {
                     memory._isClear[i] = true;
                 }
-                _json = JsonUtility.ToJson(memory);
-                StreamWriter wr = new StreamWriter(_filepath, false);
-                wr.WriteLine(_json);
-                wr.Close();
+                Save(memory);
             }
             public void OverWriteAll()
             {
-                StreamReader rd = new StreamReader(_filepath);
-                _json = rd.ReadToEnd();
-                rd.Close();
-                SaveData memory = JsonUtility.FromJson<SaveData>(_json);
+                SaveData memory = Load(_filepath);
                 for (int i = 0; i < memory._isClear.Length; i++)
                 {
                     memory._isClear[i] = true;
                 }
-                _json = JsonUtility.ToJson(memory);
-                StreamWriter wr = new StreamWriter(_filepath, false);
-                Debug.Log(_json);
-                wr.WriteLine(_json);
-                wr.Close();
+                Save(memory);
             }
-            public void Clearzero()
+            public void ChangeFavchar(int num)
             {
-                int num = 0;
-                OverWrite(num);
-            }
-            public void Clear1st()
-            {
-                int num = 1;
-                OverWrite(num);
-            }
-            public void Clear2nd()
-            {
-                int num = 2;
-                OverWrite(num);
-            }
-            public void Clear3rd()
-            {
-                int num = 3;
-                OverWrite(num);
-            }
+                SaveData memory = Load(_filepath);
+                memory._favoriteUnitId = num;
+                Save(memory);
+            }          
+            
         }
     }
 }

--- a/Assets/System/SaveSystem/SceneTransButtonController.cs
+++ b/Assets/System/SaveSystem/SceneTransButtonController.cs
@@ -9,14 +9,33 @@ namespace TeamB_TD
     {
         public class SceneTransButtonController : MonoBehaviour, IPointerClickHandler
         {
-            [SerializeField, SceneName] 
+            [SerializeField, SceneName]
             private string _nextScene;
+            [SerializeField, SceneName]
+            private string _anotherNextScene;
+            [SerializeField]
+            bool _sceneDivergence = false;
+
+            public string NextScene
+            {
+                get { return _nextScene; }
+                set { _nextScene = value; }
+            }
 
             bool _isActive = true;
             public bool Active { set { _isActive = value; } }
 
             public void OnPointerClick(PointerEventData pointerEventData)
             {
+                
+                if(_sceneDivergence)
+                {
+                    if(DataManager.Instance.PlayerData._favoriteUnitId != 0)
+                    {
+                        SceneTransition.instance.SceneTrans(_anotherNextScene);
+                        return;
+                    }                    
+                }
                 if (_isActive)
                 {
                     SceneTransition.instance.SceneTrans(_nextScene);


### PR DESCRIPTION
DataManagerが他のオブジェクトにプレイヤーのデータを渡すための変数をセーブ処理時に更新していなかったので修正。推しキャラ選択画面からのシーン遷移とセーブデータの書き込みの処理を別のオブジェクトで行っていたので統一。推しキャラを既に選択済みの場合、タイトルシーンからステージ選択画面に直接遷移できる機能の追加

## タスク概要
* 

## 具体的にやったこと
* 

## 動作確認用のスクショや動画
* 

## その他
* 
