### PR TITLE
セーブデータのロード関数にセーブデータのファイルパスを引数としていたのを引数なしにした。

### DIFF
--- a/Assets/OutGame/FavCharaSelect/DecideListener.cs
+++ b/Assets/OutGame/FavCharaSelect/DecideListener.cs
@@ -35,7 +35,7 @@ namespace TeamB_TD
             {
                 _filepath = Application.streamingAssetsPath + "/SaveData/SaveData.json";
                 _imgCanvas.gameObject.GetComponent<Image>().sprite = _charImgArray[_currentNum];
-                memory = DataManager.Instance.Load(_filepath);
+                memory = DataManager.Instance.Load();
             }
             private void Start()
             {

--- a/Assets/Result/GameResultController.cs
+++ b/Assets/Result/GameResultController.cs
@@ -2,6 +2,7 @@
 using TeamB_TD.Battle.Unit.Enemy;
 using TeamB_TD.Battle.Tower;
 using TeamB_TD.UI;
+using TeamB_TD.SaveData;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using static UnityEngine.Rendering.DebugUI;
@@ -12,6 +13,7 @@ namespace TeamB_TD
     {
         public class GameResultController : MonoBehaviour
         {
+            [SerializeField] int _stageNum = 0;
             [SerializeField] GameResultViewer _gameResultViewer;
             [SerializeField] GameClearAnimation _gameClearAnimation;
             //[SerializeField] TowerController _towerController;
@@ -33,6 +35,10 @@ namespace TeamB_TD
                 _gameResultViewer.ScorePanelChangeActive(true);
                 StartCoroutine(_gameResultViewer.ScorePanelSet());
                 yield return _gameClearAnimation.StarImageAnimationStart();
+
+                SaveData.SaveData instantData = DataManager.Instance.Load();
+                instantData._isClear[_stageNum] = true;
+                DataManager.Instance.Save(instantData);
             }
 
             public void GameOverResultSet()

--- a/Assets/System/SaveSystem/DataManager.cs
+++ b/Assets/System/SaveSystem/DataManager.cs
@@ -49,7 +49,7 @@ namespace TeamB_TD
                     Debug.Log(_filepath);
                     Save(_pData);
                 }
-                _pData = Load(_filepath);
+                _pData = Load();
             }
             public void Save(SaveData data)
             {
@@ -59,11 +59,19 @@ namespace TeamB_TD
                 wr.WriteLine(_json);
                 wr.Flush();
                 wr.Close();
-                _pData = Load(_filepath);
+                _pData = Load();
             }
-            public SaveData Load(string path)
+            //public SaveData Load(string path) //セーブデータを複数取り扱う場合はDictionary
+            //{
+            //    StreamReader rd = new StreamReader(path);
+            //    _json = rd.ReadToEnd();
+            //    rd.Close();
+
+            //    return JsonUtility.FromJson<SaveData>(_json);
+            //}
+            public SaveData Load()
             {
-                StreamReader rd = new StreamReader(path);
+                StreamReader rd = new StreamReader(_filepath);
                 _json = rd.ReadToEnd();
                 rd.Close();
 
@@ -71,7 +79,7 @@ namespace TeamB_TD
             }
             public void Reset()
             {
-                SaveData memory = Load(_filepath);
+                SaveData memory = Load();
                 for (int i = 0; i < memory._isClear.Length; i++)
                 {
                     memory._isClear[i] = false;
@@ -84,7 +92,7 @@ namespace TeamB_TD
             // TODO:機能整い次第削除
             public void OverWrite(int stagenum) //特定のステージのクリア状況を変更する
             {
-                SaveData memory = Load(_filepath);
+                SaveData memory = Load();
                 for (int i = 0; i < stagenum; i++)
                 {
                     memory._isClear[i] = true;
@@ -93,7 +101,7 @@ namespace TeamB_TD
             }
             public void OverWriteAll()
             {
-                SaveData memory = Load(_filepath);
+                SaveData memory = Load();
                 for (int i = 0; i < memory._isClear.Length; i++)
                 {
                     memory._isClear[i] = true;
@@ -102,7 +110,7 @@ namespace TeamB_TD
             }
             public void ChangeFavchar(int num)
             {
-                SaveData memory = Load(_filepath);
+                SaveData memory = Load();
                 memory._favoriteUnitId = num;
                 Save(memory);
             }          


### PR DESCRIPTION
ステージクリア後のGameResultControlerの動作にステージのクリア状況をセーブデータファイルに書き込む処理を追加

## タスク概要
* 

## 具体的にやったこと
* 

## 動作確認用のスクショや動画
* 

## その他
* 
