### PR TITLE
[fixed] リザルトのアニメーション終了まで画面遷移しないように修正

### DIFF
--- a/Assets/Result/GameResultController.cs
+++ b/Assets/Result/GameResultController.cs
@@ -5,7 +5,6 @@ using TeamB_TD.UI;
 using TeamB_TD.SaveData;
 using UnityEngine;
 using UnityEngine.EventSystems;
-using static UnityEngine.Rendering.DebugUI;
 
 namespace TeamB_TD
 {
@@ -20,12 +19,6 @@ namespace TeamB_TD
 
             public GameResultViewer GameResultViewer => _gameResultViewer;
 
-            //test用
-            //private void Start()
-            //{
-            //    StartCoroutine(GameClearResultSet());
-            //}
-
             public IEnumerator GameClearResultSet()
             {
                 //_gameResultViewer.TowerHPSet(_towerController.Life);
@@ -35,6 +28,7 @@ namespace TeamB_TD
                 _gameResultViewer.ScorePanelChangeActive(true);
                 StartCoroutine(_gameResultViewer.ScorePanelSet());
                 yield return _gameClearAnimation.StarImageAnimationStart();
+                _gameResultViewer.ResultClickPanelChangeActive(true);
 
                 SaveData.SaveData instantData = DataManager.Instance.Load();
                 instantData._isClear[_stageNum] = true;

--- a/Assets/Result/GameResultViewer.cs
+++ b/Assets/Result/GameResultViewer.cs
@@ -1,9 +1,7 @@
 ﻿using System.Collections;
 using UnityEngine;
-using UnityEngine.Events;
 using UnityEngine.UI;
 using DG.Tweening;
-using Unity.VisualScripting;
 using TeamB_TD.SaveData;
 
 namespace TeamB_TD
@@ -22,6 +20,8 @@ namespace TeamB_TD
             private GameObject _scorePanel;
             [SerializeField]
             private GameObject _scoreChildPanel;
+            [SerializeField]
+            private GameObject _resultClickPanel;
             [SerializeField]
             private Image _charaImage;
             [SerializeField]
@@ -68,6 +68,11 @@ namespace TeamB_TD
             public void ScorePanelChangeActive(bool value)
             {
                 _scorePanel.SetActive(value);
+            }
+
+            public void ResultClickPanelChangeActive(bool value)
+            {
+                _resultClickPanel.SetActive(value);
             }
 
             public IEnumerator ScorePanelSet()

--- a/Assets/Result/ResultCanvas.prefab
+++ b/Assets/Result/ResultCanvas.prefab
@@ -864,6 +864,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b9713d2910914964ab123a401caac11f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _stageNum: 0
   _gameResultViewer: {fileID: -5168809724053188006}
   _gameClearAnimation: {fileID: 2571827220864712581}
 --- !u!114 &-5168809724053188006
@@ -883,7 +884,12 @@ MonoBehaviour:
   _gameclearPanel: {fileID: 1602536570805090294}
   _scorePanel: {fileID: 5863088950773674391}
   _scoreChildPanel: {fileID: 1283433164032187726}
+  _resultClickPanel: {fileID: 6689638236113225603}
   _charaImage: {fileID: 7609710018253892471}
+  _charSpriteArray: []
+  _dispImgPos: {x: 0, y: 0}
+  _dispImgSizeWidth: 0
+  _dispImgSizeHeight: 0
 --- !u!1 &2744674915363498241
 GameObject:
   m_ObjectHideFlags: 0
@@ -1570,7 +1576,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &8219648924116591871
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1641,6 +1647,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 15ddde4ff50b0ca4d8d4e019689ee7b7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _nextSceneName: 
 --- !u!1 &7190179585142556443
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Result/ResultClick.cs
+++ b/Assets/Result/ResultClick.cs
@@ -6,9 +6,9 @@ public class ResultClick : MonoBehaviour ,IPointerClickHandler
 {
     [SerializeField]
     private string _nextSceneName = default;
+
     public void OnPointerClick(PointerEventData eventData)
     {
-        Debug.Log("クリックされた");
         SceneTransition.instance.SceneTrans(_nextSceneName);
     }
 }


### PR DESCRIPTION
## タスク概要
* 上記の通り

## 具体的にやったこと
* アニメーション終了後、クリック用のパネルのSetActiveをtrue

## 動作確認用のスクショや動画
* 

## その他
* 
